### PR TITLE
Develop styles pdf

### DIFF
--- a/accounts/templates/accounts/signup.html
+++ b/accounts/templates/accounts/signup.html
@@ -19,37 +19,33 @@
   <div class="tela-login" style="height: 100%; padding-bottom: 60px">
     <img src="{% static "img/logo.png" %}" alt="logo_painel">
     <form method="POST" class="tela-login" action="{% url 'signup' %}"
-      style="margin-top: 0px; justify-content: flex-start;">
+      style="margin-top: 0px; justify-content: flex-start; width: fit-content">
       <h3>Cadastro</h3>
       {% csrf_token %}
-      <input placeholder="Usuário" type="text" name="username" autocapitalize="none" autocomplete="username"
-        maxlength="150" required="" id="id_username">
+      <input placeholder="Usuário" type="text" name="username" autocapitalize="none" autocomplete="username" maxlength="150" required="" id="id_username" style="background-color: white">
       <span style="font-size: small; font-weight: normal; text-align: start;">{{ form.username.errors }}</span>
-      <input placeholder="Email" type="email" name="email" autocomplete="current-password" required="" id="">
-      <select name="instituicao" id="id_instituicao">
+      <input placeholder="Email" type="email" name="email" autocomplete="current-password" required="" id="" style="background-color: white">
+      <select name="instituicao" id="id_instituicao" style="background-color: white">
         <option value="PM">Polícia Militar</option>
         <option value="MPRJ">MPRJ</option>
       </select>
       <div style="position: relative; display: inline-block;">
-        <input placeholder="Senha" type="password" name="password1" autocomplete="current-password" required=""
-          id="id_password1" style="padding-right: 30px;">
-        <button type="button" onclick="togglePassword('id_password1', 'eye-icon1')" id="toggle-password"
-          style="position: absolute; right: 10px; cursor: pointer; border: none; background: none; width: auto;">
-          <i id="eye-icon" class="fas fa-eye" style="color: white;"></i>
+        <input placeholder="Senha" type="password" name="password1" autocomplete="current-password" required id="id_password1" style="padding-right: 30px; background-color: white">
+        <button type="button" onclick="togglePassword('id_password1', 'eye-icon1')" id="toggle-password" style="position: absolute; right: 10px; cursor: pointer; border: none; background: none; width: auto;">
+          <i id="eye-icon" class="fas fa-eye" style="color: #292929;"></i>
         </button>
       </div>
       <span style="font-size: small; font-weight: normal; text-align: start;">{{ form.password1.errors }}</span>
       <div style="position: relative; display: inline-block;">
-        <input placeholder="Confirmação de senha" type="password" name="password2" autocomplete="current-password"
-          required="" id="id_password2" style="padding-right: 30px;">
+        <input placeholder="Confirmação de senha" type="password" name="password2" autocomplete="current-password" required id="id_password2" style="padding-right: 30px; background-color: white">
         <button type="button" onclick="togglePassword('id_password2', 'eye-icon2')" id="toggle-password"
           style="position: absolute; right: 10px; cursor: pointer; border: none; background: none; width: auto;">
-          <i id="eye-icon" class="fas fa-eye" style="color: white;"></i>
+          <i id="eye-icon" class="fas fa-eye" style="color: #292929;"></i>
         </button>
       </div>
 
       <span style="font-size: small; font-weight: normal; text-align: start;">{{ form.password2.errors }}</span>
-      <button type="submit">Enviar</button>
+      <button type="submit" style="width: 100%; border: none">Enviar</button>
     </form>
   </div>
   <img src="{% static "img/logo-MP.png" %}" alt="logo_MP">

--- a/operations/scripts/exports.py
+++ b/operations/scripts/exports.py
@@ -1,0 +1,183 @@
+import os
+from uuid import UUID
+
+from django.conf import settings
+from datetime import date, datetime, time
+from io import BytesIO
+from pathlib import Path
+from reportlab.lib.colors import HexColor
+from reportlab.pdfbase.pdfmetrics import stringWidth
+from reportlab.pdfgen import canvas
+
+from operations.models import Operacao
+
+
+
+def date_or_time_formatter(data):
+    if isinstance(data, datetime): 
+        return data.strftime("%d/%m/%Y %H:%M")  
+    elif isinstance(data, date):  
+        return data.strftime("%d/%m/%Y") 
+    elif isinstance(data, time): 
+        return data.strftime("%H:%M")
+    return data
+
+
+
+def include_header(p, width, is_first_page=False):
+    img_header = os.path.join(settings.BASE_DIR, "static", "img", "bg-inicial-page.png")
+    p.drawImage(img_header, 0, heightTotal - 88, width=width, height=88)
+    
+    p.setFont("Helvetica", 12)
+    p.setFillColor(HexColor("#353535"))
+    total_text = "Emitido em: " + date_or_time_formatter(datetime.now())
+    
+    totaltext_y = heightTotal - 88 - 40 
+    p.drawString(
+        width - stringWidth(total_text, "Helvetica", 12) - 30,
+        totaltext_y, 
+        total_text
+    )
+    
+    protected_area = 20 
+    
+    if is_first_page:
+        return totaltext_y - protected_area - 80
+    else:
+        return totaltext_y - protected_area
+
+
+
+def include_footer(p, width, n):
+    pg_number = f"Página {n}" 
+    
+    p.setStrokeColor(HexColor("#F7CF32"))
+    p.setLineWidth(10)
+    p.line(0, 0, width, 0)  
+    
+    p.setFont("Helvetica", 10)
+    p.drawString(
+        width - stringWidth(pg_number, "Helvetica", 10) - 30, 
+        15, 
+        pg_number
+    )
+
+
+
+def break_text(text, max_width, font_name="Helvetica", font_size=12):
+    lines = []
+    current_line = []
+    current_width = 0
+    
+    for word in text.split():
+        word_width = stringWidth(word + ' ', font_name, font_size)
+        
+        if stringWidth(word, font_name, font_size) > max_width:
+            temp_word = ''
+            for char in word:
+                char_width = stringWidth(char, font_name, font_size)
+                if current_width + char_width <= max_width:
+                    temp_word += char
+                    current_width += char_width
+                else:
+                    if temp_word:
+                        current_line.append(temp_word)
+                        lines.append(' '.join(current_line))
+                    current_line = []
+                    current_width = 0
+                    temp_word = char
+                    current_width += char_width
+            if temp_word:
+                current_line.append(temp_word)
+        else:
+            if current_width + word_width <= max_width:
+                current_line.append(word)
+                current_width += word_width
+            else:
+                lines.append(' '.join(current_line))
+                current_line = [word]
+                current_width = word_width
+    
+    if current_line:
+        lines.append(' '.join(current_line))
+    
+    return lines
+
+
+
+def generate_pdf_file(operacaoUUID):
+    global widthTotal, heightTotal
+    widthTotal, heightTotal = 595, 841
+    
+    margin_left = (widthTotal - 535) / 2 
+    content_width = 535 
+    
+    try:
+        base_dir = Path(f"{settings.BASE_DIR}/query")
+        query = (base_dir / "query.sql").read_text()
+        operacaoUUID = UUID(str(operacaoUUID))  
+        operacoes = Operacao.objects.raw(query, [operacaoUUID])
+        attributes = operacoes[0].__dict__.copy()
+        attributes.pop("_state", None)
+    except (Operacao.DoesNotExist, ValueError) as e:
+        print(f"Erro ao buscar operação: {e}")  
+        return None  
+
+    buffer = BytesIO()
+    p = canvas.Canvas(buffer, pagesize=(widthTotal, heightTotal))
+    
+    pg_number = 1
+    available_height = include_header(p, widthTotal, is_first_page=True)
+    
+    footer_height = 35
+    min_height = footer_height
+    
+    p.setFont("Helvetica-Bold", 16)
+    titulo = "Visualizar operação"
+    p.drawString(margin_left, available_height, titulo)
+    available_height -= 30 
+    
+    p.setStrokeColor(HexColor("#F7CF32"))
+    p.setLineWidth(2)
+    p.line(margin_left, available_height, margin_left + content_width, available_height)
+    available_height -= 30
+    
+    p.setFont("Helvetica", 12)
+    line_height = 14
+    space_betw_items = 10
+    
+    ignored_keys = ["id", "Criado em", "Seção Atual", "Dado registrado fora do sistema", "Cadastro Completo"]
+    
+    for key, value in attributes.items():
+        if key in ignored_keys:
+            continue
+        
+        # Tratamento dos valores
+        shown_value = ("não preenchido" if value is None or value == "" or value == " " else
+                        "sim" if isinstance(value, bool) and value else
+                        "não" if isinstance(value, bool) else
+                        date_or_time_formatter(value))
+        
+        complete_txt = f"{key}: {shown_value}"
+        lines = break_text(complete_txt, content_width, "Helvetica", 12)
+        
+        for line in lines:
+            if available_height < min_height + line_height:
+                include_footer(p, widthTotal, pg_number)
+                p.showPage()
+                pg_number += 1
+                available_height = include_header(p, widthTotal)
+                p.setFont("Helvetica", 12)
+            
+            p.drawString(margin_left, available_height, line)
+            available_height -= line_height
+        
+        available_height -= space_betw_items
+        
+        if key == "Cartuchos Apreendidos":
+            break
+    
+    include_footer(p, widthTotal, pg_number)
+    p.save()
+    buffer.seek(0)
+    return buffer

--- a/operations/scripts/exports.py
+++ b/operations/scripts/exports.py
@@ -2,6 +2,7 @@ import os
 from uuid import UUID
 
 from django.conf import settings
+from django.template import Template, Context
 from datetime import date, datetime, time
 from io import BytesIO
 from pathlib import Path
@@ -105,6 +106,19 @@ def break_text(text, max_width, font_name="Helvetica", font_size=12):
 
 
 
+
+def load_query(where_condition=None):
+    query_path = os.path.join(settings.BASE_DIR, 'query', 'query.sql')
+    
+    with open(query_path, 'r', encoding='utf-8') as file:
+        query_sql = file.read()
+    
+    if where_condition:
+        return query_sql.replace('/* WHERE_CONDITION */', f'WHERE {where_condition}')
+    return query_sql.replace('/* WHERE_CONDITION */', '')
+
+
+
 def generate_pdf_file(operacaoUUID):
     global widthTotal, heightTotal
     widthTotal, heightTotal = 595, 841
@@ -113,12 +127,13 @@ def generate_pdf_file(operacaoUUID):
     content_width = 535 
     
     try:
-        base_dir = Path(f"{settings.BASE_DIR}/query")
-        query = (base_dir / "query.sql").read_text()
         operacaoUUID = UUID(str(operacaoUUID))  
-        operacoes = Operacao.objects.raw(query, [operacaoUUID])
+        where_condition = "op.identificador = %s"
+        query_sql = load_query(where_condition)
+        operacoes = Operacao.objects.raw(query_sql, [str(operacaoUUID)])        
         attributes = operacoes[0].__dict__.copy()
         attributes.pop("_state", None)
+        
     except (Operacao.DoesNotExist, ValueError) as e:
         print(f"Erro ao buscar operação: {e}")  
         return None  
@@ -185,6 +200,3 @@ def generate_pdf_file(operacaoUUID):
     return buffer
 
 
-
-def generate_excel_file():
-    return

--- a/operations/scripts/exports.py
+++ b/operations/scripts/exports.py
@@ -183,3 +183,8 @@ def generate_pdf_file(operacaoUUID):
     p.save()
     buffer.seek(0)
     return buffer
+
+
+
+def generate_excel_file():
+    return

--- a/operations/scripts/exports.py
+++ b/operations/scripts/exports.py
@@ -156,6 +156,8 @@ def generate_pdf_file(operacaoUUID):
         shown_value = ("não preenchido" if value is None or value == "" or value == " " else
                         "sim" if isinstance(value, bool) and value else
                         "não" if isinstance(value, bool) else
+                        "programada" if value == "Pr" else
+                        "emergencial" if value == "Em" else
                         date_or_time_formatter(value))
         
         complete_txt = f"{key}: {shown_value}"

--- a/operations/urls.py
+++ b/operations/urls.py
@@ -72,4 +72,9 @@ urlpatterns = [
         views.generate_pdf,
         name="generate_pdf"
     ),
+    path(
+        "gerar-excel/",
+        views.generate_excel,
+        name="generate_excel"
+    )
 ]

--- a/operations/urls.py
+++ b/operations/urls.py
@@ -68,9 +68,8 @@ urlpatterns = [
         views.OperationListView.as_view(), 
         name="operations-list"),
     path(
-        "generate-pdf/<uuid:identificador>/",
+        "gerar-pdf/<uuid:identificador>/",
         views.generate_pdf,
         name="generate_pdf"
     ),
-
 ]

--- a/operations/views.py
+++ b/operations/views.py
@@ -360,6 +360,8 @@ def generate_pdf(request, identificador):
 
 def generate_excel(request):
     try:
+        ignored_columns = ["id", "Criado em", "Seção Atual", "Dado registrado fora do sistema", "Cadastro Completo"]
+        
         query_sql = load_query() 
         
         with connection.cursor() as cursor:
@@ -368,6 +370,8 @@ def generate_excel(request):
             data = cursor.fetchall()
         
         df = pd.DataFrame(data, columns=columns)
+        
+        df = df.drop(columns=ignored_columns, errors='ignore')
         
         for col in df.columns:
             if pd.api.types.is_datetime64_any_dtype(df[col]):
@@ -388,4 +392,4 @@ def generate_excel(request):
     except FileNotFoundError:
         return HttpResponse("Arquivo query.sql não encontrado", status=404)
     except Exception as e:
-        return HttpResponse(f"Erro ao exportar dados: {str(e)}", status=500)
+        return HttpResponse(f"Erro ao exportar dados: {str(e)}", status=500)  

--- a/operations/views.py
+++ b/operations/views.py
@@ -1,18 +1,11 @@
-import os
 import uuid
 
-from datetime import date, datetime, time
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import FileResponse, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import ListView, TemplateView
 from django.urls import reverse
-from io import BytesIO
-from pathlib import Path
-from reportlab.lib.colors import HexColor
-from reportlab.pdfbase.pdfmetrics import stringWidth
-from reportlab.pdfgen import canvas
 from uuid import UUID
 
 from coredata.models import Bairro, Municipio
@@ -27,6 +20,7 @@ from operations.serializers import (
     InfoResultadosTwoSerializer,
     InfoResultadosThreeSerializer
 )
+from .scripts.exports import generate_pdf_file
 
 URL_SECTION_MAPPER = {
     1: "operations:form-update",
@@ -342,181 +336,9 @@ class InitialPageListView(LoginRequiredMixin, TemplateView):
 
 
 
-def date_or_time_formatter(data):
-    if isinstance(data, datetime): 
-        return data.strftime("%d/%m/%Y %H:%M")  
-    elif isinstance(data, date):  
-        return data.strftime("%d/%m/%Y") 
-    elif isinstance(data, time): 
-        return data.strftime("%H:%M")
-    return data
-
-
-
-def include_header(p, width, is_first_page=False):
-    img_header = os.path.join(settings.BASE_DIR, "static", "img", "bg-inicial-page.png")
-    p.drawImage(img_header, 0, heightTotal - 88, width=width, height=88)
-    
-    p.setFont("Helvetica", 12)
-    p.setFillColor(HexColor("#353535"))
-    total_text = "Emitido em: " + date_or_time_formatter(datetime.now())
-    
-    totaltext_y = heightTotal - 88 - 40 
-    p.drawString(
-        width - stringWidth(total_text, "Helvetica", 12) - 30,
-        totaltext_y, 
-        total_text
-    )
-    
-    protected_area = 20 
-    
-    if is_first_page:
-        return totaltext_y - protected_area - 80
-    else:
-        return totaltext_y - protected_area
-
-
-
-def include_footer(p, width, n):
-    pg_number = f"Página {n}" 
-    
-    p.setStrokeColor(HexColor("#F7CF32"))
-    p.setLineWidth(10)
-    p.line(0, 0, width, 0)  
-    
-    p.setFont("Helvetica", 10)
-    p.drawString(
-        width - stringWidth(pg_number, "Helvetica", 10) - 30, 
-        15, 
-        pg_number
-    )
-
-
-
-def break_text(text, max_width, font_name="Helvetica", font_size=12):
-    lines = []
-    current_line = []
-    current_width = 0
-    
-    for word in text.split():
-        word_width = stringWidth(word + ' ', font_name, font_size)
-        
-        if stringWidth(word, font_name, font_size) > max_width:
-            temp_word = ''
-            for char in word:
-                char_width = stringWidth(char, font_name, font_size)
-                if current_width + char_width <= max_width:
-                    temp_word += char
-                    current_width += char_width
-                else:
-                    if temp_word:
-                        current_line.append(temp_word)
-                        lines.append(' '.join(current_line))
-                    current_line = []
-                    current_width = 0
-                    temp_word = char
-                    current_width += char_width
-            if temp_word:
-                current_line.append(temp_word)
-        else:
-            if current_width + word_width <= max_width:
-                current_line.append(word)
-                current_width += word_width
-            else:
-                lines.append(' '.join(current_line))
-                current_line = [word]
-                current_width = word_width
-    
-    if current_line:
-        lines.append(' '.join(current_line))
-    
-    return lines
-
-
-
-def generate_pdf_file(operacaoUUID):
-    global widthTotal, heightTotal
-    widthTotal, heightTotal = 595, 841
-    
-    margin_left = (widthTotal - 535) / 2 
-    content_width = 535 
-    
-    try:
-        base_dir = Path(f"{settings.BASE_DIR}/query")
-        query = (base_dir / "query.sql").read_text()
-        operacaoUUID = UUID(str(operacaoUUID))  
-        operacoes = Operacao.objects.raw(query, [operacaoUUID])
-        attributes = operacoes[0].__dict__.copy()
-        attributes.pop("_state", None)
-    except (Operacao.DoesNotExist, ValueError) as e:
-        print(f"Erro ao buscar operação: {e}")  
-        return None  
-
-    buffer = BytesIO()
-    p = canvas.Canvas(buffer, pagesize=(widthTotal, heightTotal))
-    
-    pg_number = 1
-    available_height = include_header(p, widthTotal, is_first_page=True)
-    
-    footer_height = 35
-    min_height = footer_height
-    
-    p.setFont("Helvetica-Bold", 16)
-    titulo = "Visualizar operação"
-    p.drawString(margin_left, available_height, titulo)
-    available_height -= 30 
-    
-    p.setStrokeColor(HexColor("#F7CF32"))
-    p.setLineWidth(2)
-    p.line(margin_left, available_height, margin_left + content_width, available_height)
-    available_height -= 30
-    
-    p.setFont("Helvetica", 12)
-    line_height = 14
-    space_betw_items = 10
-    
-    ignored_keys = ["id", "Criado em", "Seção Atual", "Dado registrado fora do sistema", "Cadastro Completo"]
-    
-    for key, value in attributes.items():
-        if key in ignored_keys:
-            continue
-        
-        # Tratamento dos valores
-        shown_value = ("não preenchido" if value is None or value == "" or value == " " else
-                        "sim" if isinstance(value, bool) and value else
-                        "não" if isinstance(value, bool) else
-                        date_or_time_formatter(value))
-        
-        complete_txt = f"{key}: {shown_value}"
-        lines = break_text(complete_txt, content_width, "Helvetica", 12)
-        
-        for line in lines:
-            if available_height < min_height + line_height:
-                include_footer(p, widthTotal, pg_number)
-                p.showPage()
-                pg_number += 1
-                available_height = include_header(p, widthTotal)
-                p.setFont("Helvetica", 12)
-            
-            p.drawString(margin_left, available_height, line)
-            available_height -= line_height
-        
-        available_height -= space_betw_items
-        
-        if key == "Cartuchos Apreendidos":
-            break
-    
-    include_footer(p, widthTotal, pg_number)
-    p.save()
-    buffer.seek(0)
-    return buffer
-
-
-
 def generate_pdf(request, identificador):
     try:
-        identificador = UUID(str(identificador))  
-        logger.info(f"UUID recebido na view (convertido): {identificador} ({type(identificador)})")
+        identificador = UUID(str(identificador))
 
         buffer = generate_pdf_file(identificador)
         if not buffer:
@@ -525,9 +347,7 @@ def generate_pdf(request, identificador):
         return FileResponse(buffer, as_attachment=True, filename='operacao.pdf')
 
     except ValueError as e:
-        logger.error(f"UUID inválido recebido: {identificador}. Erro: {e}")
         return HttpResponse("UUID inválido.", status=400)
 
     except Exception as e:
-        logger.error(f"Erro ao gerar PDF: {e}")
         return HttpResponse(f"Erro interno do servidor: {e}", status=500)

--- a/operations/views.py
+++ b/operations/views.py
@@ -20,7 +20,7 @@ from operations.serializers import (
     InfoResultadosTwoSerializer,
     InfoResultadosThreeSerializer
 )
-from .scripts.exports import generate_pdf_file
+from .scripts.exports import generate_pdf_file, generate_excel_file
 
 URL_SECTION_MAPPER = {
     1: "operations:form-update",
@@ -348,6 +348,18 @@ def generate_pdf(request, identificador):
 
     except ValueError as e:
         return HttpResponse("UUID inválido.", status=400)
+
+    except Exception as e:
+        return HttpResponse(f"Erro interno do servidor: {e}", status=500)
+
+
+
+def generate_excel(request):
+    try:
+
+        buffer = generate_excel_file()
+
+        return FileResponse(buffer, as_attachment=True, filename='operacao.pdf')
 
     except Exception as e:
         return HttpResponse(f"Erro interno do servidor: {e}", status=500)

--- a/operations/views.py
+++ b/operations/views.py
@@ -1,11 +1,14 @@
+import pandas as pd
 import uuid
 
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db import connection
 from django.http import FileResponse, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import ListView, TemplateView
 from django.urls import reverse
+from io import BytesIO
 from uuid import UUID
 
 from coredata.models import Bairro, Municipio
@@ -20,7 +23,7 @@ from operations.serializers import (
     InfoResultadosTwoSerializer,
     InfoResultadosThreeSerializer
 )
-from .scripts.exports import generate_pdf_file, generate_excel_file
+from .scripts.exports import generate_pdf_file, load_query
 
 URL_SECTION_MAPPER = {
     1: "operations:form-update",
@@ -354,12 +357,35 @@ def generate_pdf(request, identificador):
 
 
 
+
 def generate_excel(request):
     try:
-
-        buffer = generate_excel_file()
-
-        return FileResponse(buffer, as_attachment=True, filename='operacao.pdf')
-
+        query_sql = load_query() 
+        
+        with connection.cursor() as cursor:
+            cursor.execute(query_sql)
+            columns = [col[0] for col in cursor.description]
+            data = cursor.fetchall()
+        
+        df = pd.DataFrame(data, columns=columns)
+        
+        for col in df.columns:
+            if pd.api.types.is_datetime64_any_dtype(df[col]):
+                df[col] = df[col].dt.tz_localize(None)
+        
+        output = BytesIO()
+        with pd.ExcelWriter(output, engine='xlsxwriter') as writer:
+            df.to_excel(writer, index=False, sheet_name='Dados')
+        
+        output.seek(0)
+        response = HttpResponse(
+            output.getvalue(),
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        )
+        response['Content-Disposition'] = 'attachment; filename="exportacao_dados.xlsx"'
+        return response
+    
+    except FileNotFoundError:
+        return HttpResponse("Arquivo query.sql não encontrado", status=404)
     except Exception as e:
-        return HttpResponse(f"Erro interno do servidor: {e}", status=500)
+        return HttpResponse(f"Erro ao exportar dados: {str(e)}", status=500)

--- a/operations/views.py
+++ b/operations/views.py
@@ -1,18 +1,16 @@
 import os
-import logging
 import uuid
 
 from datetime import date, datetime, time
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import FileResponse, HttpResponse
+from django.http import FileResponse, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import ListView, TemplateView
 from django.urls import reverse
 from io import BytesIO
 from pathlib import Path
 from reportlab.lib.colors import HexColor
-from reportlab.lib.pagesizes import A4
 from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.pdfgen import canvas
 from uuid import UUID
@@ -29,8 +27,6 @@ from operations.serializers import (
     InfoResultadosTwoSerializer,
     InfoResultadosThreeSerializer
 )
-
-logger = logging.getLogger(__name__)
 
 URL_SECTION_MAPPER = {
     1: "operations:form-update",
@@ -318,7 +314,6 @@ class FormCompleteView(LoginRequiredMixin, TemplateView):
         self.operacao.make_complete()
         return response
 
-from django.http import JsonResponse
 
 class OperationListView(LoginRequiredMixin, ListView):
     template_name = "operations/operations_list_template.html"
@@ -346,72 +341,59 @@ class InitialPageListView(LoginRequiredMixin, TemplateView):
     template_name = "operations/initial_page_template.html"
 
 
-def format_and_exclud(atributos):
-    for chave, valor in atributos.items():
-        print(valor, type(valor))
- 
-    return atributos
 
-
-
-def date_or_time_formatter(valor):
-    if isinstance(valor, datetime): 
-        return valor.strftime("%d/%m/%Y %H:%M")  
-    elif isinstance(valor, date):  
-        return valor.strftime("%d/%m/%Y") 
-    elif isinstance(valor, time): 
-        return valor.strftime("%H:%M")
-    return valor
+def date_or_time_formatter(data):
+    if isinstance(data, datetime): 
+        return data.strftime("%d/%m/%Y %H:%M")  
+    elif isinstance(data, date):  
+        return data.strftime("%d/%m/%Y") 
+    elif isinstance(data, time): 
+        return data.strftime("%H:%M")
+    return data
 
 
 
 def include_header(p, width, is_first_page=False):
-    """Inclui o cabeçalho com espaçamento adequado"""
     img_header = os.path.join(settings.BASE_DIR, "static", "img", "bg-inicial-page.png")
     p.drawImage(img_header, 0, heightTotal - 88, width=width, height=88)
     
     p.setFont("Helvetica", 12)
     p.setFillColor(HexColor("#353535"))
-    texto_emitido = "Emitido em: " + date_or_time_formatter(datetime.now())
+    total_text = "Emitido em: " + date_or_time_formatter(datetime.now())
     
-    # Posição do texto "Emitido em:" mais para baixo
-    emitido_em_y = heightTotal - 88 - 40  # Aumentado de 30 para 40 pixels
+    totaltext_y = heightTotal - 88 - 40 
     p.drawString(
-        width - stringWidth(texto_emitido, "Helvetica", 12) - 30,
-        emitido_em_y, 
-        texto_emitido
+        width - stringWidth(total_text, "Helvetica", 12) - 30,
+        totaltext_y, 
+        total_text
     )
     
-    # Área protegida abaixo do texto "Emitido em:"
-    protected_area = 20  # Espaço adicional de proteção
+    protected_area = 20 
     
-    # Altura disponível após o header
     if is_first_page:
-        return emitido_em_y - protected_area - 80  # Espaço para título e linha
+        return totaltext_y - protected_area - 80
     else:
-        return emitido_em_y - protected_area
+        return totaltext_y - protected_area
 
 
 
 def include_footer(p, width, n):
-    # Corrigindo a concatenação de string com inteiro
-    texto_pagina = f"Página {n}"  # Usando f-string para formatar corretamente
+    pg_number = f"Página {n}" 
     
     p.setStrokeColor(HexColor("#F7CF32"))
     p.setLineWidth(10)
-    p.line(0, 0, width, 0)  # Linha amarela no footer
+    p.line(0, 0, width, 0)  
     
     p.setFont("Helvetica", 10)
     p.drawString(
-        width - stringWidth(texto_pagina, "Helvetica", 10) - 30,  # Margem direita de 30px
-        15,  # Posição vertical ajustada
-        texto_pagina
+        width - stringWidth(pg_number, "Helvetica", 10) - 30, 
+        15, 
+        pg_number
     )
 
 
 
 def break_text(text, max_width, font_name="Helvetica", font_size=12):
-    """Quebra texto considerando a largura máxima com margens"""
     lines = []
     current_line = []
     current_width = 0
@@ -419,9 +401,7 @@ def break_text(text, max_width, font_name="Helvetica", font_size=12):
     for word in text.split():
         word_width = stringWidth(word + ' ', font_name, font_size)
         
-        # Se a palavra for maior que a largura máxima, quebra a palavra
         if stringWidth(word, font_name, font_size) > max_width:
-            # Processa cada caractere da palavra
             temp_word = ''
             for char in word:
                 char_width = stringWidth(char, font_name, font_size)
@@ -458,17 +438,16 @@ def generate_pdf_file(operacaoUUID):
     global widthTotal, heightTotal
     widthTotal, heightTotal = 595, 841
     
-    # Configurações de margem e conteúdo
-    margin_left = (widthTotal - 535) / 2  # Centraliza os 535px de conteúdo
-    content_width = 535  # Largura fixa do conteúdo
+    margin_left = (widthTotal - 535) / 2 
+    content_width = 535 
     
     try:
         base_dir = Path(f"{settings.BASE_DIR}/query")
         query = (base_dir / "query.sql").read_text()
         operacaoUUID = UUID(str(operacaoUUID))  
         operacoes = Operacao.objects.raw(query, [operacaoUUID])
-        atributos = operacoes[0].__dict__.copy()
-        atributos.pop("_state", None)
+        attributes = operacoes[0].__dict__.copy()
+        attributes.pop("_state", None)
     except (Operacao.DoesNotExist, ValueError) as e:
         print(f"Erro ao buscar operação: {e}")  
         return None  
@@ -476,62 +455,58 @@ def generate_pdf_file(operacaoUUID):
     buffer = BytesIO()
     p = canvas.Canvas(buffer, pagesize=(widthTotal, heightTotal))
     
-    pagina = 1
-    altura_disponivel = include_header(p, widthTotal, is_first_page=True)
+    pg_number = 1
+    available_height = include_header(p, widthTotal, is_first_page=True)
     
-    # Configurações de footer
     footer_height = 35
-    altura_minima = footer_height
+    min_height = footer_height
     
-    # Elementos exclusivos da primeira página
     p.setFont("Helvetica-Bold", 16)
     titulo = "Visualizar operação"
-    p.drawString(margin_left, altura_disponivel, titulo)
-    altura_disponivel -= 30 
+    p.drawString(margin_left, available_height, titulo)
+    available_height -= 30 
     
     p.setStrokeColor(HexColor("#F7CF32"))
     p.setLineWidth(2)
-    p.line(margin_left, altura_disponivel, margin_left + content_width, altura_disponivel)
-    altura_disponivel -= 30
+    p.line(margin_left, available_height, margin_left + content_width, available_height)
+    available_height -= 30
     
-    # Configurações de texto
     p.setFont("Helvetica", 12)
     line_height = 14
-    espacamento_entre_itens = 10
+    space_betw_items = 10
     
-    # Lista de atributos a ignorar
-    chaves_ignoradas = ["id", "Criado em", "Seção Atual", "Dado registrado fora do sistema", "Cadastro Completo"]
+    ignored_keys = ["id", "Criado em", "Seção Atual", "Dado registrado fora do sistema", "Cadastro Completo"]
     
-    for chave, valor in atributos.items():
-        if chave in chaves_ignoradas:
+    for key, value in attributes.items():
+        if key in ignored_keys:
             continue
         
         # Tratamento dos valores
-        valor_exibido = ("não preenchido" if valor is None or valor == "" or valor == " " else
-                        "sim" if isinstance(valor, bool) and valor else
-                        "não" if isinstance(valor, bool) else
-                        date_or_time_formatter(valor))
+        shown_value = ("não preenchido" if value is None or value == "" or value == " " else
+                        "sim" if isinstance(value, bool) and value else
+                        "não" if isinstance(value, bool) else
+                        date_or_time_formatter(value))
         
-        texto_completo = f"{chave}: {valor_exibido}"
-        linhas = break_text(texto_completo, content_width, "Helvetica", 12)
+        complete_txt = f"{key}: {shown_value}"
+        lines = break_text(complete_txt, content_width, "Helvetica", 12)
         
-        for linha in linhas:
-            if altura_disponivel < altura_minima + line_height:
-                include_footer(p, widthTotal, pagina)
+        for line in lines:
+            if available_height < min_height + line_height:
+                include_footer(p, widthTotal, pg_number)
                 p.showPage()
-                pagina += 1
-                altura_disponivel = include_header(p, widthTotal)
+                pg_number += 1
+                available_height = include_header(p, widthTotal)
                 p.setFont("Helvetica", 12)
             
-            p.drawString(margin_left, altura_disponivel, linha)
-            altura_disponivel -= line_height
+            p.drawString(margin_left, available_height, line)
+            available_height -= line_height
         
-        altura_disponivel -= espacamento_entre_itens
+        available_height -= space_betw_items
         
-        if chave == "Cartuchos Apreendidos":
+        if key == "Cartuchos Apreendidos":
             break
     
-    include_footer(p, widthTotal, pagina)
+    include_footer(p, widthTotal, pg_number)
     p.save()
     buffer.seek(0)
     return buffer

--- a/query/query.sql
+++ b/query/query.sql
@@ -132,4 +132,4 @@ LEFT JOIN operations_roapensado ro ON orc.roapensado_id = ro.id
 -- Join para CartuchosCalibresApreendidos
 LEFT JOIN operacao_cartuchos_calibres oc ON op.id = oc.operacao_id
 LEFT JOIN operations_cartuchocalibresapreendidos cc ON oc.cartuchocalibresapreendidos_id = cc.id
-WHERE op.identificador = %s;
+/* WHERE_CONDITION */

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -14,20 +14,20 @@
   </div>
   <div class="tela-login" style="padding-bottom: 60px;">
     <img src="{% static "img/logo.png" %}" alt="logo_painel">
-    <form method="POST" class="tela-login" style="margin-top: 0px; justify-content: flex-start;">
+    <form method="POST" class="tela-login" style="margin-top: 0px; justify-content: flex-start; width: fit-content">
       <h3>Login</h3>
       {% csrf_token %}
       <input placeholder="Login PCERJ" type="text" name="username" autocapitalize="none" autocomplete="username"
-        maxlength="150" required="" id="id_username">
+        maxlength="150" required id="id_username" style="background-color: white">
       <div style="position: relative; display: inline-block;">
-        <input placeholder="Senha" type="password" name="password" autocomplete="current-password" required=""
-          id="id_password" style="padding-right: 30px;">
+        <input placeholder="Senha" type="password" name="password" autocomplete="current-password" required
+          id="id_password" style="padding-right: 30px; background-color: white">
         <button type="button" onclick="togglePassword()" id="toggle-password"
           style="position: absolute; right: 10px; cursor: pointer; border: none; background: none; width: auto;">
-          <i id="eye-icon" class="fas fa-eye" style="color: white;"></i>
+          <i id="eye-icon" class="fas fa-eye" style="color: #292929;"></i>
         </button>
       </div>
-      <button type="submit">Entrar</button>
+      <button type="submit" style="width: 100%; border: none">Entrar</button>
       {% if form.non_field_errors %}
       <ul style="color: #fff; list-style: none; font-weight: normal; font-size: small; margin-top: 40px;">
         {% for error in form.non_field_errors %}
@@ -55,23 +55,5 @@
       eyeIcon.classList.add("fa-eye");
     }
   }
-
-  function updateEyeColor() {
-    var inputs = ["id_password1", "id_password2"];
-    inputs.forEach(function (inputId) {
-      var input = document.getElementById(inputId);
-      var icon = document.getElementById("eye-icon" + inputId.slice(-1));
-      var bgColor = window.getComputedStyle(input).backgroundColor;
-
-      if (bgColor === "rgb(0, 0, 0)") { // Preto
-        icon.style.color = "white";
-      } else { // Branco ou outro
-        icon.style.color = "black";
-      }
-    });
-  }
-
-  document.addEventListener("DOMContentLoaded", updateEyeColor);
-  window.addEventListener("load", updateEyeColor);
 </script>
 {% endblock content %}


### PR DESCRIPTION
Adicionado css inline nos inputs das páginas de login e cadastro para branco, olhinho escuro para aparecer (funcional)

Limpeza geral do código

Transferência das funções auxiliares do pdf e excel para operations/scripts/exports.py

Adicionado mascaramento do tipo de operação no pdf 

Implementado exportação de todas as operações em excel com colunas ignoradas SEM MASCARAMENTO de dados

Alterado query.sql usado por ambos pdf e excel, adicionado parâmetro where
